### PR TITLE
Fix the path to resources that do not depend on the structure of the file system.

### DIFF
--- a/Config/AppConfig/Applications.json
+++ b/Config/AppConfig/Applications.json
@@ -1,7 +1,7 @@
 //  $Source: /Users/bbennett/pass/archive/PosdaAppMacConfig/AppConfig/Applications.json,v $
 //  $Date: 2014/09/22 18:42:12 $
 //  $Revision: 1.3 $
-// 
+//
 {
   "SocketPool": [
     64614, 64615, 64616, 64617, 64618, 64619, 64620,
@@ -10,7 +10,7 @@
   ],
   "Apps": {
     "DicomXmlBrowsing": {
-      "Directory": "/Users/bbennett/posda-gsoc/Config/DicomXml",
+      "Directory": "Config/DicomXml",
       "Application" : "AppController.pl <host> <port> <dir> <color>",
       "Description" : "Browse Docbook Version of DICOM Standard",
       "WindowName" : "_new",
@@ -24,7 +24,7 @@
     },
   },
   "BomDirs": {
-    "Posda": "/Users/bbennett/posda-gsoc/Posda",
-    "DicomXml": "/Users/bbennett/posda-gsoc/DicomXml",
+    "Posda": "Posda",
+    "DicomXml": "DicomXml",
   },
 }

--- a/Config/AppConfig/Environment.json
+++ b/Config/AppConfig/Environment.json
@@ -1,14 +1,14 @@
 //  $Source: /Users/bbennett/pass/archive/PosdaAppMacConfig/AppConfig/Environment.json,v $
 //  $Date: 2014/09/22 18:37:47 $
 //  $Revision: 1.2 $
-// 
+//
 {
   "ApplicationInitClass" : "AppController::JavaScriptApp",
   "ApplicationInitMethod" : "InitApp",
   "ApplicationLoginMethod" : "NullLogin",
   "ApplicationName" : "Testing Application Server",
-  "AppHttpRoot" : "/Users/bbennett/posda-gsoc/HttpRoot/http_root",
+  "AppHttpRoot" : "HttpRoot/http_root",
   "AuthenticationDbType" : "File",
   "AuthenticationDbFileName" : "/Volumes/5TEncrypted/cache/Login.db",
-  "JavascriptRoot" : "/Users/bbennett/posda-gsoc/Posda/javascript",
+  "JavascriptRoot" : "Posda/javascript",
 }

--- a/Config/DicomXml/Environment.json
+++ b/Config/DicomXml/Environment.json
@@ -1,14 +1,14 @@
 //  $Source: /Users/bbennett/pass/archive/PosdaAppMacConfig/DicomXml/Environment.json,v $
 //  $Date: 2014/09/22 18:46:45 $
 //  $Revision: 1.1 $
-// 
+//
 {
   "ApplicationInitClass" : "DicomXml::Application",
   "ApplicationInitMethod" : "InitApp",
   "ApplicationLoginMethod" : "NullLogin",
   "ApplicationName" : "Start",
-  "AppHttpRoot" : "/Users/bbennett/posda-gsoc/HttpRoot/http_root",
-  "ParsedDicomRoot" : "/Users/bbennett/posda-gsoc/ParsedDicom",
-  "DicomXmlRoot" : "/Users/bbennett/posda-gsoc/DicomXml/docbook",
-  "ParsedIodRoot" : "/Users/bbennett/posda-gsoc/ParsedIods",
+  "AppHttpRoot" : "HttpRoot/http_root",
+  "ParsedDicomRoot" : "ParsedDicom",
+  "DicomXmlRoot" : "DicomXml/docbook",
+  "ParsedIodRoot" : "ParsedIods",
 }


### PR DESCRIPTION
Hi Bill,

The configuration of paths to resources for application pointed to a specific path that had to be fixed if you start a project with a different folder structure. So I fixed the path so as not to depend on folder structure.

Thank you,
Roman
